### PR TITLE
Fixed:remove copyright notice from the readme #27

### DIFF
--- a/Gen 3/mwc-nfv-hackathon/README.md
+++ b/Gen 3/mwc-nfv-hackathon/README.md
@@ -1,29 +1,3 @@
-###############################################################################
-##
-# Copyright 2017-2018 VMware Inc.
-# This file is part of VNF-ONboarding
-# All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#         http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
-#
-# For those usages not covered by the Apache License, Version 2.0 please
-# contact:  osslegalrouting@vmware.com
- 
-##
- 
-##############################################################################
-
-
 VNF onboarding Wizard
 =====================
 

--- a/Gen 3/mwc-nfv-hackathon/templates/README.md
+++ b/Gen 3/mwc-nfv-hackathon/templates/README.md
@@ -1,30 +1,3 @@
-############################################################################
-##
-# Copyright 2017-2018 VMware Inc.
-# This file is part of VNF-ONboarding
-# All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#         http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
-#
-# For those usages not covered by the Apache License, Version 2.0 please
-# contact:  osslegalrouting@vmware.com
- 
-##
- 
-#############################################################################
-
-
-
 
 VNF onboarding with Cloudify
 ============================

--- a/Gen 3/mwc-nfv-hackathon/wizard/readme.md
+++ b/Gen 3/mwc-nfv-hackathon/wizard/readme.md
@@ -1,35 +1,3 @@
-/*#########################################################################
-##
-# Copyright 2017-2018 VMware Inc.
-# This file is part of VNF-ONboarding
-# All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#         http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
-#
-# For those usages not covered by the Apache License, Version 2.0 please
-# contact:  osslegalrouting@vmware.com
- 
-##
- 
-########################################################################### */
-
-
-
-
-
-
-
-
 Install packages with 
 ```
 npm install


### PR DESCRIPTION
The copyright notice are removed from following README.md files:
1)  mwc-nfv-hackathon/README.md
2)  mwc-nfv-hackathon/templates/README.md
3) mwc-nfv-hackathon/wizard/readme.md

