### PR TITLE
RIFT.io related changes for Issue #18,19 & 31

### DIFF
--- a/Gen 3/mwc-nfv-hackathon/backend/backend.py
+++ b/Gen 3/mwc-nfv-hackathon/backend/backend.py
@@ -57,9 +57,9 @@ def login_page():
   if request.data == "":
      return "false"
   credentials = json.loads(request.data)
-  #if credentials['username'] == "admin" and credentials['password'] == "admin" :
-  print(credentials['username'] ,credentials['password'],credentials['session_key']) 
-  if db_check_credentials(credentials['username'] ,credentials['password']):
+  if credentials['username'] == "admin" and credentials['password'] == "admin" :
+        print(credentials['username'] ,credentials['password'],credentials['session_key']) 
+  #if db_check_credentials(credentials['username'] ,credentials['password']):
         print ("Found UP")
         return "true" 
   return "false"

--- a/Gen 3/mwc-nfv-hackathon/backend/backend.py
+++ b/Gen 3/mwc-nfv-hackathon/backend/backend.py
@@ -57,9 +57,9 @@ def login_page():
   if request.data == "":
      return "false"
   credentials = json.loads(request.data)
-  if credentials['username'] == "admin" and credentials['password'] == "admin" :
+  #if credentials['username'] == "admin" and credentials['password'] == "admin" :
+  if db_check_credentials(credentials['username'] ,credentials['password']):
         print(credentials['username'] ,credentials['password'],credentials['session_key']) 
-  #if db_check_credentials(credentials['username'] ,credentials['password']):
         print ("Found UP")
         return "true" 
   return "false"

--- a/Gen 3/mwc-nfv-hackathon/templates/OS-RIFTware-NSD-template.yaml
+++ b/Gen 3/mwc-nfv-hackathon/templates/OS-RIFTware-NSD-template.yaml
@@ -1,0 +1,100 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# For those usages not covered by the Apache License, Version 2.0 please
+# contact:  osslegalrouting@vmware.com
+
+##
+
+###########################################################################
+nsd:nsd-catalog:
+    nsd:nsd:
+    -   nsd:id: {{ vnfd_name }}_nsd
+        nsd:name: {{ vnfd_name }}_nsd
+        nsd:short-name: {{ vnfd_name }}_nsd
+        nsd:description: {{ vnf_description }}
+        nsd:vendor: 'RIFT.io'
+        nsd:version: '1.0'
+
+        # Place the logo as png in icons directory and provide the name here
+        # nsd:logo: <update, optional>
+
+        # Specify the VNFDs that are part of this NSD
+        nsd:constituent-vnfd:
+            # The member-vnf-index needs to be unique, starting from 1
+            # vnfd-id-ref is the id of the VNFD
+            # Multiple constituent VNFDs can be specified
+        -   nsd:member-vnf-index: 1
+            nsd:vnfd-id-ref: {{ vnfd_name }}_vnfd
+
+        vld:
+        # Networks for the VNFs
+            -   nsd:id: {{ vnfd_name }}_mgmt1_vld
+                nsd:name: management
+                nsd:short-name: management
+                nsd:type: ELAN
+                nsd:mgmt-network: 'true'
+                # Specify the constituent VNFs
+                # member-vnf-index-ref - entry from constituent vnf
+                # vnfd-id-ref - VNFD id
+                # vnfd-connection-point-ref - connection point name in the VNFD
+                nsd:vnfd-connection-point-ref:
+                -   nsd:member-vnf-index-ref: 1
+                    nsd:vnfd-id-ref: {{ vnfd_name }}_vnfd
+                    nsd:vnfd-connection-point-ref: mgmt1
+{% if nic2_name %}
+            -   nsd:id: {{ vnfd_name }}_net2_vld 
+                nsd:name: {{ vnfd_name }}_net2_vld
+                nsd:type: ELAN
+                nsd:mgmt-network: 'false'
+                nsd:vnfd-connection-point-ref:
+                -   nsd:member-vnf-index-ref: 1
+                    nsd:vnfd-id-ref: {{ vnfd_name }}_vnfd
+                    nsd:vnfd-connection-point-ref: cp2
+{% endif %}{% if nic3_name %}
+            -   nsd:id: {{ vnfd_name }}_net3_vld 
+                nsd:name: {{ vnfd_name }}_net3_vld
+                nsd:type: ELAN
+                nsd:mgmt-network: 'false'
+                nsd:vnfd-connection-point-ref:
+                -   nsd:member-vnf-index-ref: 1
+                    nsd:vnfd-id-ref: {{ vnfd_name }}_vnfd
+                    nsd:vnfd-connection-point-ref: cp3
+{% endif %}{% if nic4_name %}
+            -   nsd:id: {{ vnfd_name }}_net4_vld 
+                nsd:name: {{ vnfd_name }}_net4_vld
+                nsd:type: ELAN
+                nsd:mgmt-network: 'false'
+                nsd:vnfd-connection-point-ref:
+                -   nsd:member-vnf-index-ref: 1
+                    nsd:vnfd-id-ref: {{ vnfd_name }}_vnfd
+                    nsd:vnfd-connection-point-ref: cp4
+{% endif %}{% if nic5_name %}
+            -   nsd:id: {{ vnfd_name }}_net5_vld 
+                nsd:name: {{ vnfd_name }}_net5_vld
+                nsd:type: ELAN
+                nsd:mgmt-network: 'false'
+                nsd:vnfd-connection-point-ref:
+                -   nsd:member-vnf-index-ref: 1
+                    nsd:vnfd-id-ref: {{ vnfd_name }}_vnfd
+                    nsd:vnfd-connection-point-ref: cp5
+{% endif %}{% if nic6_name %}
+            -   nsd:id: {{ vnfd_name }}_net6_vld 
+                nsd:name: {{ vnfd_name }}_net6_vld
+                nsd:type: ELAN
+                nsd:mgmt-network: 'false'
+                nsd:vnfd-connection-point-ref:
+                -   nsd:member-vnf-index-ref: 1
+                    nsd:vnfd-id-ref: {{ vnfd_name }}_vnfd
+                    nsd:vnfd-connection-point-ref: cp6
+{% endif %}
+

--- a/Gen 3/mwc-nfv-hackathon/templates/OS-RIFTware-template.yaml
+++ b/Gen 3/mwc-nfv-hackathon/templates/OS-RIFTware-template.yaml
@@ -1,0 +1,110 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# For those usages not covered by the Apache License, Version 2.0 please
+# contact:  osslegalrouting@vmware.com
+
+##
+
+###########################################################################
+vnfd:vnfd-catalog:
+    vnfd:vnfd:
+    -   vnfd:id: {{ vnfd_name }}_vnfd
+        vnfd:name: {{ vnfd_name }}
+        vnfd:short-name: {{ vnfd_name }}
+        vnfd:description: {{ vnf_description }}
+        vnfd:vendor: 'RIFT.io'
+        vnfd:version: '1.0'
+
+        # Place the logo as png in icons directory and provide the name here
+        # vnfd:logo: <update, optional>
+
+        # Atleast one VDU need to be specified
+        vnfd:vdu:
+        -   vnfd:id: {{ vnfd_name }}_vdu
+            vnfd:name: {{ vnfd_name }}_vdu
+            vnfd:count: 1
+
+            # Flavour of the VM to be instantiated for the VDU
+            vnfd:vm-flavor:
+                vnfd:vcpu-count: {{ cpu }}
+                vnfd:memory-mb: {{ ram }}
+                vnfd:storage-gb: {{ disk }}
+
+            # Image including the full path
+            vnfd:image: {{ image_id }}{% if scripts.create %}
+            # Cloud init file
+            vnfd:cloud-init-file: {{scripts.create}}{% endif %}
+
+            vnfd:guest-epa:{% if memory_reservation %}
+                vnfd:mempage-size: "PREFER_LARGE"{% else %}
+                vnfd:mempage-size: "SMALL"{% endif %}{% if latency_sensitivity %}
+                vnfd:cpu-pinning-policy: "DEDICATED"{% else %}
+                vnfd:cpu-pinning-policy: "ANY"{% endif %}{% if numa_affinity %}
+                vnfd:numa-node-policy:
+                    vnfd:node-cnt: {{ number_numa_node }}{% endif %}
+
+            vnfd:interface:
+            # Specify the external interfaces
+            # There can be multiple interfaces defined
+            -   vnfd:name: {{ nic1_name }}
+                vnfd:type: EXTERNAL {% if Interfaces1_name %}
+                vnfd:position: 1
+                vnfd:virtual-interface:
+                    vnfd:type: {{ Interfaces1_name }} {% endif %}
+                vnfd:external-connection-point-ref: mgmt1 {% if nic2_name %}
+            -   vnfd:name: {{ nic2_name }}
+                vnfd:type: EXTERNAL {% if Interfaces2_name %}
+                vnfd:position: 2
+                vnfd:virtual-interface:
+                    vnfd:type: {{ Interfaces2_name }} {% endif %}
+                vnfd:external-connection-point-ref: cp2 {% endif %}{% if nic3_name %}
+            -   vnfd:name: {{ nic3_name }}
+                vnfd:type: EXTERNAL {% if Interfaces3_name %}
+                vnfd:position: 3
+                vnfd:virtual-interface:
+                    vnfd:type: {{ Interfaces3_name }} {% endif %}
+                vnfd:external-connection-point-ref: cp3 {% endif %}{% if nic4_name %}
+            -   vnfd:name: {{ nic4_name }}
+                vnfd:type: EXTERNAL {% if Interfaces4_name %}
+                vnfd:position: 4
+                vnfd:virtual-interface:
+                    vnfd:type: {{ Interfaces4_name }} {% endif %}
+                vnfd:external-connection-point-ref: cp4 {% endif %} {% if nic5_name %}
+            -   vnfd:name: {{ nic5_name }}
+                vnfd:type: EXTERNAL {% if Interfaces5_name %}
+                vnfd:position: 5
+                vnfd:virtual-interface:
+                    vnfd:type: {{ Interfaces5_name }} {% endif %}
+                vnfd:external-connection-point-ref: cp5 {% endif %} {% if nic6_name %}
+            -   vnfd:name: {{ nic6_name }}
+                vnfd:type: EXTERNAL {% if Interfaces6_name %}
+                vnfd:position: 6
+                vnfd:virtual-interface:
+                    vnfd:type: {{ Interfaces6_name }} {% endif %}
+                vnfd:external-connection-point-ref: cp6 {% endif %}
+ 
+        vnfd:connection-point:
+            # Specify the connection points
+            # There can be multiple connection points defined
+            -   vnfd:name: mgmt1
+                vnfd:type: VPORT {% if nic2_name %}
+            -   vnfd:name: cp2
+                vnfd:type: VPORT {% endif %} {% if nic3_name %}
+            -   vnfd:name: cp3
+                vnfd:type: VPORT {% endif %} {% if nic4_name %}
+            -   vnfd:name: cp4
+                vnfd:type: VPORT {% endif %} {% if nic5_name %}
+            -   vnfd:name: cp5
+                vnfd:type: VPORT {% endif %} {% if nic6_name %}
+            -   vnfd:name: cp6
+                vnfd:type: VPORT {% endif %}

--- a/Gen 3/mwc-nfv-hackathon/templates/README.md
+++ b/Gen 3/mwc-nfv-hackathon/templates/README.md
@@ -1,4 +1,5 @@
 {% if orch_type == 'Cloudify 4.0' %}
+
 VNF onboarding with Cloudify
 ============================
 
@@ -56,6 +57,7 @@ Run your VNF with Cloudify and follow steps below.
     `cfy blueprints delete -b {{ vnf_name }}-{{ env_type }}`
 
 {% elif orch_type == "TOSCA 1.1" %}
+
 Standard TOSCA blueprint
 ------------------------
 
@@ -72,6 +74,7 @@ Standard TOSCA blueprint
 
 
 {% elif orch_type == "RIFT.ware 5.3" %}
+
 VNF Onboarding with RIFT.io
 ===========================
 

--- a/Gen 3/mwc-nfv-hackathon/templates/README.md
+++ b/Gen 3/mwc-nfv-hackathon/templates/README.md
@@ -1,4 +1,4 @@
-
+{% if orch_type == 'Cloudify 4.0' %}
 VNF onboarding with Cloudify
 ============================
 
@@ -55,7 +55,7 @@ Run your VNF with Cloudify and follow steps below.
     `cfy deployments delete -d {{ vnf_name }}-{{ env_type }}`
     `cfy blueprints delete -b {{ vnf_name }}-{{ env_type }}`
 
-
+{% elif orch_type == "TOSCA 1.1" %}
 Standard TOSCA blueprint
 ------------------------
 
@@ -71,27 +71,27 @@ Standard TOSCA blueprint
    `aria parse {{ vnf_name }}-{{ env_type }}/{{ vnf_name }}-{{ env_type }}-TOSCA.yaml instance`
 
 
-
+{% elif orch_type == "RIFT.ware 5.3" %}
 VNF Onboarding with RIFT.io
 ===========================
 
 Objects that are created in the directory structure:
 
-1. Virtual Network Function Descriptor (VNFD) for the VNF in YAML format.
+1. This 'README.md' file
 
-2. Folder <vnf-name>_vnfd that contains files required for the VNF package.
+2. Archive of the VNF descriptor {{vnf_type}}-{{env_type}}-{{ vnfd_name }}_vnfd.tar.gz for onboarding to the resource orchestrator. Untar-ing this gives:
+   a. Folder {{vnf_type}}-{{env_type}}-{{ vnfd_name }}_vnfd that contains all files required for the VNF package.
+   b. Virtual Network Function Descriptor (VNFD) for the VNF in YAML format.
 
-3. Archive of the VNF descriptor in tar.gz format for onboarding to the resource orchestrator
+3. Archive of the NS descriptor {{vnf_type}}-{{env_type}}-{{ vnfd_name }}_nsd.tar.gz for onboarding to the resource orchestrator. Untar-ing this gives:
+   a. Folder {{vnf_type}}-{{env_type}}-{{ vnfd_name }}_nsd that contains all files required for the NS package
+   b. Network Service Descriptor (NSD) for the VNF in YAML format.
 
-4. Network Service Descriptor (NSD) for the VNF in YAML format.
-
-5. Folder <vnf-name>_nsd that contains files required for the NS package
-
-6. Archive of the NS descriptor in tar.gz format for onboarding to the resource orchestrator
 
 Copy the gzipped packages to a location that is accessible by a browser for RIFT.ware onboarding, such as to your laptop or desktop system.
 
 Browse to the RIFT.ware UI to sign in to the Launchpad and proceed with onboarding. Checkout https://open.riftio.com/documentation/ for more information.
 
-
+{% else %}
 # VNF-Onboarding
+{% endif %}

--- a/Gen 3/mwc-nfv-hackathon/wizard/src/app/components/scripts_definitions_component.js
+++ b/Gen 3/mwc-nfv-hackathon/wizard/src/app/components/scripts_definitions_component.js
@@ -44,7 +44,7 @@ module.exports = {
 	this.OrchType = config.OrchType;
 	var scriptsInputs; 
 	
-	if (this.OrchType == 'OSM 3.0' || this.OrchType == 'RIFT.ware 5.3'){	
+	if (this.OrchType == 'OSM 3.0'){	
 		 
 		this.scriptsInputs = {
 			create: this.scriptsInputsconfig['create']
@@ -86,7 +86,7 @@ module.exports = {
       var config_final = {};
     if (isValid) {
 
-		if (this.OrchType == 'OSM 3.0' || this.OrchType == 'RIFT.ware 5.3'){
+		if (this.OrchType == 'OSM 3.0'){
 
 			config_final = {
 					create: emptyToString(this.scriptsInputs['create'].value)

--- a/Gen 3/mwc-nfv-hackathon/wizard/src/app/components/vnf_definition_component.js
+++ b/Gen 3/mwc-nfv-hackathon/wizard/src/app/components/vnf_definition_component.js
@@ -113,18 +113,17 @@ module.exports = {
       return this.OrchTypeSelected === this.RIFT_NAME;
     };
    
-   
     this.isOSM_VCDClass = function() {
         if((this.FlavorSelected == "auto") &&(this.isOpenStack()) &&(this.OrchTypeSelected == 'TOSCA 1.1')){
             return this.FORM_GROUP;
         }
         else{
-            return ((this.isOSM())|| (this.isVCD())) ? this.DISABLED_FORM_GROUP : this.FORM_GROUP;
+            return ((this.isOSM())|| (this.isRIFT()) || (this.isVCD())) ? this.DISABLED_FORM_GROUP : this.FORM_GROUP;
         }
     };
     
     this.isOSM_TOSCA_CUSTOM_FLAVOR_Class = function() {
-        if((this.FlavorSelected == "auto") &&(this.isOpenStack()) &&(this.OrchTypeSelected == 'TOSCA 1.1' || this.OrchTypeSelected == 'Cloudify 3.4' || this.OrchTypeSelected == 'Cloudify 4.0' || this.OrchTypeSelected == 'RIFT.ware 5.3')){
+        if((this.FlavorSelected == "auto") &&(this.isOpenStack()) &&(this.OrchTypeSelected == 'TOSCA 1.1' || this.OrchTypeSelected == 'Cloudify 3.4' || this.OrchTypeSelected == 'Cloudify 4.0' )){
 	     return this.FORM_GROUP
         }
         else{
@@ -133,11 +132,11 @@ module.exports = {
     };
     
     this.isOSM_or_VCD_Class = function() {
-        if((this.FlavorSelected == "auto") &&(this.isOpenStack()) &&(this.OrchTypeSelected == 'TOSCA 1.1' || this.OrchTypeSelected == 'Cloudify 3.4' || this.OrchTypeSelected == 'Cloudify 4.0' || this.OrchTypeSelected == 'RIFT.ware 5.3')){
+        if((this.FlavorSelected == "auto") &&(this.isOpenStack()) &&(this.OrchTypeSelected == 'TOSCA 1.1' || this.OrchTypeSelected == 'Cloudify 3.4' || this.OrchTypeSelected == 'Cloudify 4.0' )){
 	     return this.FORM_GROUP
         }
         else{
-           return ((this.isOSM())|| (this.isVCD())) ? this.FORM_GROUP : this.DISABLED_FORM_GROUP;
+           return ((this.isOSM())|| (this.isRIFT()) || (this.isVCD())) ? this.FORM_GROUP : this.DISABLED_FORM_GROUP;
         }
     };
     this.isCUSTOM_FLAVOR = function() {
@@ -149,7 +148,7 @@ module.exports = {
         }
     };
     this.isOSM_And_VCD = function() {
-      return ((this.isOSM())&& (this.isVCD())) ? true : false;
+      return ((this.isOSM() || this.isRIFT()) && (this.isVCD())) ? true : false;
     };
     this.onVNFTypeChange = function(newValue) {
       this.vnfDescription = newValue;
@@ -168,12 +167,12 @@ module.exports = {
 
       if( isValid ) {
 		  
-		if(this.VIMTypeSelected == 'vCloud Director' || (this.VIMTypeSelected == 'OpenStack' &&  this.OrchTypeSelected == 'OSM 3.0')) {
+		if(this.VIMTypeSelected == 'vCloud Director' || (this.VIMTypeSelected == 'OpenStack' &&  (this.OrchTypeSelected == 'OSM 3.0' || this.OrchTypeSelected == 'RIFT.ware 5.3'))) {
 			this.FlavorSelected = "";
 			this.flavorname = "";
 		}
 		
-		if((this.FlavorSelected != 'auto' && ( this.VIMTypeSelected == 'OpenStack' &&  (this.OrchTypeSelected == 'TOSCA 1.1' || this.OrchTypeSelected == 'Cloudify 3.4' || this.OrchTypeSelected == 'Cloudify 4.0' || this.OrchTypeSelected == 'RIFT.ware 5.3')))){
+		if((this.FlavorSelected != 'auto' && ( this.VIMTypeSelected == 'OpenStack' &&  (this.OrchTypeSelected == 'TOSCA 1.1' || this.OrchTypeSelected == 'Cloudify 3.4' || this.OrchTypeSelected == 'Cloudify 4.0' )))){
 			this.Disk = "";
 			this.RAMSelected = "";
 			this.vCPUSelected = "";


### PR DESCRIPTION
Major changes:
- Modified the RIFT.ware package generation to be based on templates, as per design
- Fixed EPA handling for RIFT.ware package generation
    * NOTE: The UI changes need to be made to enable the EPA screen for RIFT.ware
- Fixed Flavor params to only show vCPU, Men & Disk for RIFT.ware. 'Flavor' and 'Flavorname' are not supported to avoid any confusion
- Added support for providing all types of scripts